### PR TITLE
BE-9571: Add Metrics Reminders

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,11 +1,9 @@
-## Note:
-* Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?
-* Do your metrics follow the [naming conventions](https://www.notion.so/gametime/DataDog-Custom-Metrics-Usage-Naming-63c6d77879f94d04abe8fb7e14d43978?pvs=4#dcee7c9196be4a948010137927fc9337)?
-* Have you added your metric to the [Metric Notion page](https://www.notion.so/gametime/aa13f1d2282a4914a88d1524e53f959f?v=9cd24e058bd8429e937dcd5bec9892b4?)
-
-###################################################################
-
 Hello, I would like to make Gametime a better place by contributing the following code:
+
+## Observability:
+[] Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?
+[] Do your metrics follow the [naming conventions](https://www.notion.so/gametime/DataDog-Custom-Metrics-Usage-Naming-63c6d77879f94d04abe8fb7e14d43978?pvs=4#dcee7c9196be4a948010137927fc9337)?
+[] Have you added your metric to the [Metric Notion page](https://www.notion.so/gametime/aa13f1d2282a4914a88d1524e53f959f?v=9cd24e058bd8429e937dcd5bec9892b4?)
 
 ## Feature/bug description:
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,11 @@
 Hello, I would like to make Gametime a better place by contributing the following code:
 
 ## Observability:
-[] Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?
-[] Do your metrics follow the [naming conventions](https://www.notion.so/gametime/DataDog-Custom-Metrics-Usage-Naming-63c6d77879f94d04abe8fb7e14d43978?pvs=4#dcee7c9196be4a948010137927fc9337)?
-[] Have you added your metric to the [Metric Notion page](https://www.notion.so/gametime/aa13f1d2282a4914a88d1524e53f959f?v=9cd24e058bd8429e937dcd5bec9892b4?)
+- [ ] Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?
+
+- [ ] Do your metrics follow the [naming conventions](https://www.notion.so/gametime/DataDog-Custom-Metrics-Usage-Naming-63c6d77879f94d04abe8fb7e14d43978?pvs=4#dcee7c9196be4a948010137927fc9337)?
+
+- [ ] Have you added your metric to the [Metric Notion page](https://www.notion.so/gametime/aa13f1d2282a4914a88d1524e53f959f?v=9cd24e058bd8429e937dcd5bec9892b4?)
 
 ## Feature/bug description:
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 Hello, I would like to make Gametime a better place by contributing the following code:
 
 ## Observability:
-- [ ] Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?
+Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?
 
 - [ ] Do your metrics follow the [naming conventions](https://www.notion.so/gametime/DataDog-Custom-Metrics-Usage-Naming-63c6d77879f94d04abe8fb7e14d43978?pvs=4#dcee7c9196be4a948010137927fc9337)?
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,10 @@
+## Note:
+* Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?
+* Do your metrics follow the [naming conventions](https://www.notion.so/gametime/DataDog-Custom-Metrics-Usage-Naming-63c6d77879f94d04abe8fb7e14d43978?pvs=4#dcee7c9196be4a948010137927fc9337)?
+* Have you added your metric to the [Metric Notion page](https://www.notion.so/gametime/aa13f1d2282a4914a88d1524e53f959f?v=9cd24e058bd8429e937dcd5bec9892b4?)
+
+###################################################################
+
 Hello, I would like to make Gametime a better place by contributing the following code:
 
 ## Feature/bug description:


### PR DESCRIPTION
Adding a couple bullet point notes to the top of the PR template which prompt an engineer to add metrics/spans if they haven't already done so and to ensure that any metrics they add adhere to best practices re: Naming and recording in Notion. 