### PR TITLE
Reorder sections and remove internal links

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,20 +1,22 @@
 Hello, I would like to make Gametime a better place by contributing the following code:
 
-## Observability:
+## Feature/bug description
+
+## This is how I decided to implement/fix it
+
+## JIRA link
+
+## What can this break
+
+## How has this been tested
+
+## Observability
+
 Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?
 
-- [ ] Do your metrics follow the [naming conventions](https://www.notion.so/gametime/DataDog-Custom-Metrics-Usage-Naming-63c6d77879f94d04abe8fb7e14d43978?pvs=4#dcee7c9196be4a948010137927fc9337)?
+- [ ] Do your metrics follow the naming conventions?
 
-- [ ] Have you added your metric to the [Metric Notion page](https://www.notion.so/gametime/aa13f1d2282a4914a88d1524e53f959f?v=9cd24e058bd8429e937dcd5bec9892b4?)
+- [ ] Have you added your metric to the Metric Notion page?
 
-## Feature/bug description:
+### How will this change be monitored
 
-## This is how I decided to implement/fix it:
-
-## JIRA link:
-
-## What can this break:
-
-## How has this been tested:
-
-## How will this change be monitored:

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -16,7 +16,6 @@ Before opening a PR consider whether you have added sufficient observability, do
 
 - [ ] Do your metrics follow the naming conventions?
 
-- [ ] Have you added your metric to the Metric Notion page?
 
 ### How will this change be monitored
 


### PR DESCRIPTION
Couple of things.
- It makes sense to keep the change description at the top of this template.
- We should not have internal links in this repo as it is public.