### PR TITLE
feat: add pre-filled jira link to pr template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,7 +3,6 @@ The following code makes an impact.
 ## Purpose of Change
 
 ## Ticket Link
-https://gametime.atlassian.net/browse/XX-9999
 
 ## Change Overview
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,7 @@ The following code makes an impact.
 
 ## Purpose of Change
 
-## Ticket Link
+### Ticket Link
 
 ## Change Overview
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,6 +2,9 @@ The following code makes an impact.
 
 ## Purpose of Change
 
+## Ticket Link
+https://gametime.atlassian.net/browse/XX-9999
+
 ## Change Overview
 
 ## Affected Functionality


### PR DESCRIPTION
The following code makes an impact.

## Purpose of Change

Keep the PR template slim but make it easy to link to the requirements of a ticket in JIRA for review and context

## Change Overview

Add easy to update pre-filled link to Jira tickets to the Gametime PR template

## Affected Functionality

Org wide PR template will be updated, albeit slightly

## Testing

N/A

## Observability

N/A

## Rollout

Merging will rollout this template to the entire org